### PR TITLE
Enforce 4-week event limit rule.

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,6 +35,9 @@ class Config:
     self.MIN_EVENT_SPACING = 30
     # The maximum amount of future events a single user can have scheduled.
     self.USER_MAX_FUTURE_EVENTS = 10
+    # The maximum number of events a single user can have within a four-week
+    # period.
+    self.USER_MAX_FOUR_WEEKS = 6
 
     if Config.is_testing:
       logging.debug("Is testing.")


### PR DESCRIPTION
It doesn't let anyone put more than 6 events within a 4-week
period. I also added tests for this.

@billsaysthis: Please review.