### PR TITLE
Enforce the "one event per day" rule.

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,6 +39,9 @@ class Config:
     # period.
     self.USER_MAX_FOUR_WEEKS = 6
 
+    # The hours that the Dojo is open to guests. (24-hour time.)
+    self.DOJO_HOURS = (9, 17)
+
     if Config.is_testing:
       logging.debug("Is testing.")
     elif Config.is_dev:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -177,6 +177,22 @@ class NewHandlerTest(BaseTest):
     self.assertEqual(400, response.status_int)
     self.assertIn("select a room", response.body)
 
+  """ Tests that it limits people to having one event per day starting during
+  Dojo hours. """
+  def test_one_per_day(self):
+    start = datetime.datetime.now() + datetime.timedelta(days=1)
+    start = start.replace(hour=11)
+    event = models.Event(name="Test Event", start_time=start,
+                           end_time=start + datetime.timedelta(minutes=30),
+                           type="Meetup", estimated_size="10", setup=15,
+                           teardown=15, details="This is a test event.")
+    event.put()
+
+    # That should be our one event for that day. It should complain if we try to
+    # create another one.
+    response = self.test_app.post("/new", self.params, expect_errors=True)
+    self.assertEqual(400, response.status_int)
+
 
 """ Tests that the edit event handler works properly. """
 class EditHandlerTest(BaseTest):


### PR DESCRIPTION
This means that it only lets people have one event each day
starting during Dojo hours. There is an exception for admins.
There is also a test for this.

@billsaysthis: Please review.