### PR TITLE
Remove 30 day limit new members + change occupancies

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ class Config:
     self.USER_MAX_FOUR_WEEKS = 6
     # How long we have to wait after we sign up before we can create an event.
     # (days)
-    self.NEW_EVENT_WAIT_PERIOD = 30
+    self.NEW_EVENT_WAIT_PERIOD = 0
     # How long we will keep an event on hold when a user is suspended before it
     # expires. (days)
     self.SUSPENDED_EVENT_EXPIRY = 72

--- a/models.py
+++ b/models.py
@@ -12,8 +12,8 @@ import re
 from config import Config
 
 ROOM_OPTIONS = (
-    # ('Maker Space', 12),
-    ('Classroom', 16),
+    ('Maker Space', 10),
+    ('Classroom', 40),
     # ('Conference Room', 10),
     ('Large Event Room', 80),
     ('Loungey', 30),


### PR DESCRIPTION
no more 30 days limit for new members to create an event.
Room occupancies for the new space HD 3.0